### PR TITLE
Stripe script upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# custom
+scripts/stripe-data.json

--- a/scripts/data.json
+++ b/scripts/data.json
@@ -1,0 +1,122 @@
+{
+  "productCategories": [
+    "Manga", 
+    "Anime",
+    "Figurines",
+    "Cosplay"
+  ],
+  "products": [
+    {
+      "name": "Chained Soldier 1",
+      "image": "/images/chained_soldier.jpg",
+      "brand": "Yen Press",
+      "category": "Manga",
+      "description": "When down-in-the-dumps high school boy Yuuki Wakura finds himself caught up in a gate, he’s saved by Kyouka Uzen, the beautiful commander of the 7th squad of the Demon Defense Force, who…orders him to become her slave?!",
+      "price": 39000,
+      "currency": "mxn"
+    },
+    {
+      "name": "Smoking Behind the Supermarket with You 1",
+      "image": "/images/supermarket.jpg",
+      "brand": "Square Enix Manga",
+      "category": "Manga",
+      "description": "At age forty-five, office worker Sasaki has had enough of the corporate grind. His only solace is smoking—and the friendly smile of supermarket cashier Yamada. When Sasaki can't find Yamada after a particularly trying day, a striking woman invites him to smoke with her. The despondent man thinks he's made a new smoking buddy in the cool, teasing Tayama, but Sasaki doesn't realize he already knows her!",
+      "price": 40000,
+      "currency": "mxn"
+    },
+    {
+      "name": "I Want to Eat Your Pancreas",
+      "image": "/images/kiminosuizou.jpg",
+      "brand": "Seven Seas",
+      "category": "Manga",
+      "description": "In this deeply moving first-person story, an introverted high school boy finds his classmate’s diary—and learns her biggest secret. Yamauchi Sakura is dying from a pancreatic disease and now he is the only one person outside her family to know the truth. The last thing the boy wants is to be her friend, but Sakura’s cheerful demeanor and their shared secret draw them together in this heartrending tale of friendship and mortality.",
+      "price": 60000,
+      "currency": "mxn"
+    },
+    {
+      "name": "Tsubaki-chou Lonely Planet 1",
+      "image": "/images/tsubaki.jpg",
+      "brand": "Yen Press",
+      "category": "Manga",
+      "description": "Fumi Oono, second-year high-school student. Stuck with the debts of her father, she needs a job—fast. While she did indeed manage to find one as a housekeeper for THE Akatsuki Kibikino, it leaves much to be desired. After all, the novelist has a mean glare and an even worse attitude...And on top of that, she has to live with him?!",
+      "price": 30000,
+      "currency": "mxn"
+    },
+    {
+      "name": "My Dress-Up Darling: The Complete Season",
+      "image": "/images/sonobisque.jpg",
+      "brand": "Crunchy Roll",
+      "category": "Anime",
+      "description": "Marin, a cosplay enthusiast, asks Wakana to use his sewing skills to create a cosplay outfit for her. Their unlikely partnership blossoms into a sweet and spicy rom-com as they navigate the world of cosplay, build a bond, and discover the beauty in their shared passions.",
+      "price": 66000,
+      "currency": "mxn"
+    },
+    {
+      "name": "Frieren: Beyond Journey's End 1",
+      "image": "/images/frieren.jpg",
+      "brand": "Crunchy Roll",
+      "category": "Anime",
+      "description": "Frieren finds herself grappling with the concept of mortality as her friends age and die, while she continues to live for centuries. The series explores themes of regret, connection, and the value of life as Frieren embarks on new adventures with a young human apprentice, Fern, revisiting past locations and confronting her past relationships.",
+      "price": 60000,
+      "currency": "mxn"
+    },
+    {
+      "name": "Maomao",
+      "image": "/images/maomao.jpg",
+      "brand": "Good Smile",
+      "category": "Figurines",
+      "description": "From the Apothecary Diaries comes a new figurine to the Pop Up Parade collection: Maomao!",
+      "price": 80000,
+      "currency": "mxn"
+    },
+    {
+      "name": "Makoto",
+      "image": "/images/makoto.jpg",
+      "brand": "Good Smile",
+      "category": "Figurines",
+      "description": "From Persona 5, the brain of the Phantom Thieves comes as a new figurine to the Pop Up Parade collection: Makoto!",
+      "price": 120000,
+      "currency": "mxn"
+    },
+    {
+      "name": "Nier: Automata Ver. 1.1a - 2B",
+      "image": "/images/2b.jpg",
+      "brand": "S. H. Figuarts",
+      "category": "Figurines",
+      "description": "2B is a blade of quiet determination. As a combat android, she does not encourage idle chatter on frivolous subjects and is generally reticent towards others.",
+      "price": 160000,
+      "currency": "mxn"
+    },
+    {
+      "name": "Faye Valentine",
+      "image": "/images/faye.jpg",
+      "brand": "Good Smile",
+      "category": "Figurines",
+      "description": "From the popular anime Cowboy Bebop, this Figurine eatures Faye looking behind her shoulder with a daring smile on her face. Be sure to add the bounty hunter who loves to gamble to your collection!",
+      "price": 75000,
+      "currency": "mxn"
+    },
+    {
+      "name": "Bleach - Shunsui Costume Kit",
+      "image": "/images/shunsui.webp",
+      "brand": "DokiDoki Cosplay",
+      "category": "Cosplay",
+      "description": "Cosplay costume based in the outfit of Kyouraku Shunsui from the popular anime Bleach!",
+      "price": 90000,
+      "currency": "mxn"
+    },
+    {
+      "name": "Genshin Impact - Yae Miko Costume Kit",
+      "image": "/images/yaemiko.webp",
+      "brand": "DokiDoki Cosplay",
+      "category": "Cosplay",
+      "description": "Cosplay costume based in the outfit of Yae Miko from the popular gacha game Genshin Impact!",
+      "price": 150000,
+      "currency": "mxn"
+    }
+  ],
+  "customers": [
+    { "name": "Test User 51", "email": "testuser51@example.com" },
+    { "name": "Test User 52", "email": "testuser52@example.com" }
+  ]
+}

--- a/scripts/upload_stripe_data.js
+++ b/scripts/upload_stripe_data.js
@@ -1,53 +1,237 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-require-imports */
-const secretKey = process.argv[2] ?? null;
 
-initialize()
+// import required libs
+const path = require('path');
+const { existsSync, writeFileSync } = require('fs');
 
-async function initialize() {
-  if (!secretKey) {
-    console.log("❌ No API Secret Key was provided...");
+// define global variables of this script
+const scriptFlags = {
+  customInputFilePath: null,
+  customOutputFilePath: null,
+  loadCustomers: undefined,
+  loadProducts: undefined,
+  loadPrices: undefined,
+}
+
+// extract the script args provided
+const scriptArgs = process.argv.slice(2);
+if (scriptArgs.length === 0) {
+  console.log('❗️ Script was called without arguments.');
+  process.exit(1);
+}
+
+// extract all possible flag values provided
+const scriptArgFlags = scriptArgs.filter((arg) => arg.startsWith('--'));
+scriptArgFlags.forEach((argFlag) => {
+  if (argFlag.startsWith('--input-path')) {
+    const inputPath = argFlag.split('=')?.[1] ?? '';
+    if (isPathValid(inputPath)) {
+      scriptFlags.customInputFilePath = inputPath;
+    }
+    return;
+  }
+  if (argFlag.startsWith('--output-path')) {
+    const outputPath = argFlag.split('=')?.[1] ?? '';
+    if (isPathValid(outputPath)) {
+      scriptFlags.customInputFilePath = outputPath;
+    }
+    return;
+  }
+
+  switch (argFlag) {
+    case '--customers':
+      scriptFlags.loadCustomers = true;
+      break;
+    case '--products':
+      scriptFlags.loadProducts = true;
+      break;
+    case '--prices':
+      scriptFlags.loadPrices = true;
+      break;
+    default:
+      console.log(`❗️ Unknown flag detected: ${argFlag}`);
+      break;
+  }
+});
+
+// verify that one of the args is Stripe's secret key
+const secretKey = scriptArgs.find((arg) => arg.startsWith('sk_')) ?? null;
+if (!secretKey) {
+  console.log('❌ No API Secret Key was provided.');
+  process.exit(1);
+}
+
+// verify that you have a data.json file in the current dir or specified custom dir
+if (
+  !existsSync(
+    scriptFlags.customInputFilePath
+      ? path.join(scriptFlags.customInputFilePath)
+      : path.join('scripts', 'data.json')
+  )
+) {
+  console.log(`❗️ JSON data file is not present in the provided directory: ${scriptFlags.customInputFilePath ?? './data.json'}`);
+}
+
+// finally run the actual script
+executeScript();
+
+// this function loads data to Stripe using the provided secret key
+async function executeScript() {
+  try {
+    const { customInputFilePath, customOutputFilePath, loadCustomers, loadProducts, loadPrices } = scriptFlags;
+    const shouldLoadAll = loadCustomers === undefined && loadProducts === undefined && loadPrices === undefined;
+
+    const stripe = require('stripe')(secretKey);
+    const data = require(path.resolve(customInputFilePath ?? 'scripts/data.json'));
+
+    let totalErrors = 0;
+    const stripeData = {
+      customers: [],
+      products: [],
+      prices: [],
+    };
+
+    const startTime = Date.now();
+
+    if ((shouldLoadAll || !!loadCustomers) && (data?.customers?.length ?? 0) > 0) {
+      console.log('👤 Adding customers to Stripe...\n');
+
+      const customerResults = await loadDataSequentially({
+        responses: [],
+        errorsCount: 0,
+      }, data.customers.map((rawCustomer) => loadStripeCustomer(stripe, rawCustomer)));
+
+      totalErrors += customerResults.errorsCount;
+      stripeData.customers = customerResults.responses;
+
+      console.log('');
+    }
+
+    if ((shouldLoadAll || !!loadProducts) && (data?.products?.length ?? 0) > 0) {
+      console.log('📦 Adding products to Stripe...\n');
+
+      const productResults = await loadDataSequentially({
+        responses: [],
+        errorsCount: 0,
+      }, data.products.map((rawProduct) => loadStripeProduct(stripe, rawProduct)));
+
+      totalErrors += productResults.errorsCount;
+      stripeData.products = productResults.responses;
+
+      console.log('');
+
+      if ((shouldLoadAll || !!loadPrices)) {
+        console.log('💵 Adding prices to Stripe...\n');
+
+        const pricesResults = await loadDataSequentially({
+          responses: [],
+          errorsCount: 0,
+        }, productResults.responses.map((product) => loadStripePrice(stripe, {
+          ...(data.products.find((rawProduct) => rawProduct.name === product.name) ?? {}),
+          productId: product.id,
+        })));
+
+        totalErrors += pricesResults.errorsCount;
+        stripeData.prices = pricesResults.responses;
+
+        console.log('');
+      }
+    }
+
+    try {
+      writeFileSync(path.resolve(customOutputFilePath ?? 'scripts/stripe-data.json'), JSON.stringify(stripeData));
+    } catch (writeError) {
+      console.log('❌ Script failed to write the Stripe data file.', writeError);
+    }
+
+    const endTime = Date.now();
+
+    const totalTimeInSeconds = Math.abs(endTime - startTime) / 1000;
+    console.log(`✨ Finished loading all data in ${totalTimeInSeconds} seconds.\n Customers loaded: ${stripeData.customers.length} | Products loaded: ${stripeData.products.length} | Prices loaded: ${stripeData.prices.length} | Errors: ${totalErrors}`);
+  } catch (error) {
+    console.log('❌ Script failed!', error);
+  } finally {
     process.exit(1);
   }
+}
+
+function isPathValid(path) {
+  return existsSync(path);
+}
+
+function loadStripeCustomer(stripeSDK, rawCustomer) {
+  return () => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const customer = await stripeSDK.customers.create({
+          name: rawCustomer.name,
+          email: rawCustomer.email,
+        });
+        console.log(`✅ Customer ${rawCustomer.email} was added to Stripe successfully! ID: ${customer.id}`);
+        resolve(customer);
+      } catch (error) {
+        console.log(`❌ Customer ${rawCustomer.email} couldn't be added to Stripe.`, error);
+        reject(error);
+      }
+    });
+  }
+}
+
+function loadStripeProduct(stripeSDK, rawProduct) {
+  return () => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const product = await stripeSDK.products.create({
+          name: rawProduct.name,
+          description: rawProduct.description,
+          metadata: {
+            brand: rawProduct.brand,
+            category: rawProduct.category,
+            localImage: rawProduct.image,
+          }
+        });
+        console.log(`✅ Product ${rawProduct.name} was added to Stripe successfully! ID: ${product.id}`);
+        resolve(product);
+      } catch (error) {
+        console.log(`❌ Product ${rawProduct.name} couldn't be added to Stripe.`, error);
+        reject(error);
+      }
+    });
+  }
+}
+
+function loadStripePrice(stripeSDK, rawPrice) {
+  return () => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const price = await stripeSDK.prices.create({
+          unit_amount: rawPrice.price,
+          currency: rawPrice.currency,
+          product: rawPrice.productId,
+        });
+        console.log(`✅ Price for ${rawPrice.name} was added to Stripe successfully! ID: ${price.id}`);
+        resolve(price);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+}
+
+async function loadDataSequentially(state = { responses: [], errorsCount: 0 }, promises) {
+  if (promises.length === 0) {
+    return state;
+  }
+
+  const currentState = { ...state };
 
   try {
-    const stripe = require("stripe")(secretKey);
-    const data = require("./../src/constants/data.json");
-
-    let productsCount = 0;
-    let errorsCount = 0;
-
-    await Promise.all(
-      data.products.map((rawProduct) => {
-        return new Promise(async (resolve, reject) => {
-          try {
-            const product = await stripe.products.create({
-              name: rawProduct.name,
-              description: rawProduct.description,
-              metadata: {
-                brand: rawProduct.brand,
-                category: rawProduct.category,
-                localImage: rawProduct.image,
-              }
-            });
-            const price = await stripe.prices.create({
-              unit_amount: rawProduct.price,
-              currency: rawProduct.currency,
-              product: product.id,
-            });
-            productsCount += 1;
-            console.log(`✅ Product ${rawProduct.name} was uploaded successfully to Stripe with Product ID ${product.id} and Price ID ${price.id}`);
-            resolve();
-          } catch (error) {
-            errorsCount += 1;
-            console.log(`❌ Product ${rawProduct.name} couldn't be added`);
-            reject(error);
-          }
-        })
-      })
-    );
-
-    console.log(`\n✨ Finished uploading data to Stripe - Total Products: ${productsCount} | Errors: ${errorsCount}`);
+    const response = await promises?.[0]?.();
+    currentState.responses.push(response);
   } catch (error) {
-    console.log("❌ Something went wrong... ", error)
+    currentState.errorsCount += 1;
   }
+
+  return await loadDataSequentially(currentState, promises?.slice(1) ?? []);
 }


### PR DESCRIPTION
Upgraded the Stripe load script to support the following features:
- use of command flags to choose where to get the data from, where to store the resulting data and which data you want to upload.
- uploads data in a sequential way, returning one by one the customers, products and prices loaded.
- generates a _stripe-data.json_ file with the results of all the loaded data

## About the Script

To use the Script:
```bash
npm run load:stripe <sk_...> <-- --input-path="..." | --ouput-path="" | --customers | --products | --prices>
```